### PR TITLE
^0.4.0 won't match the new execa version 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "variable"
   ],
   "dependencies": {
-    "execa": "^0.4.0",
+    "execa": "^0.5.0",
     "mem": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/npm/node-semver#caret-ranges-123-025-004
